### PR TITLE
WIP: Multi-target map component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"class-variance-authority": "^0.7.1",
 				"libphonenumber-js": "^1.12.29",
 				"lucide-svelte": "^0.554.0",
+				"mapbox-gl": "^3.18.0",
 				"qrcode-generator": "^2.0.4",
 				"svelte-floating-ui": "^1.6.2",
 				"svelte-motion": "^0.12.2"
@@ -26,6 +27,7 @@
 				"@sveltejs/kit": "^2.48.5",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
 				"@tailwindcss/vite": "^4.1.17",
+				"@types/google.maps": "^3.58.1",
 				"@types/qrcode-generator": "^0.0.16",
 				"bits-ui": "^2.14.4",
 				"clsx": "^2.1.1",
@@ -553,6 +555,7 @@
 			"integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -622,6 +625,58 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"svelte": "^5"
+			}
+		},
+		"node_modules/@mapbox/jsonlint-lines-primitives": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+			"integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@mapbox/mapbox-gl-supported": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+			"integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@mapbox/point-geometry": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+			"integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+			"license": "ISC"
+		},
+		"node_modules/@mapbox/tiny-sdf": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+			"integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@mapbox/unitbezier": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@mapbox/vector-tile": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+			"integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@mapbox/point-geometry": "~1.1.0",
+				"@types/geojson": "^7946.0.16",
+				"pbf": "^4.0.1"
+			}
+		},
+		"node_modules/@mapbox/whoots-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1058,6 +1113,7 @@
 			"integrity": "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1097,6 +1153,7 @@
 			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -1436,6 +1493,28 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson-vt": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+			"integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/google.maps": {
+			"version": "3.58.1",
+			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+			"integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1446,6 +1525,12 @@
 				"@types/unist": "*"
 			}
 		},
+		"node_modules/@types/mapbox__point-geometry": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+			"integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/mdast": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1455,6 +1540,12 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
+		},
+		"node_modules/@types/pbf": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+			"integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.15",
@@ -1479,6 +1570,15 @@
 				"csstype": "^3.2.2"
 			}
 		},
+		"node_modules/@types/supercluster": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+			"integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1498,6 +1598,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1627,6 +1728,12 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/cheap-ruler": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+			"integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
+			"license": "ISC"
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1684,6 +1791,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/csscolorparser": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+			"integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
+			"license": "MIT"
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
@@ -1759,6 +1872,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/earcut": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+			"integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+			"license": "ISC"
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
@@ -1879,11 +1998,29 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/geojson-vt": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+			"integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+			"license": "ISC"
+		},
+		"node_modules/gl-matrix": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+			"integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+			"license": "MIT"
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/grid-index": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+			"integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
 			"license": "ISC"
 		},
 		"node_modules/hast-util-to-html": {
@@ -1966,6 +2103,12 @@
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
+		},
+		"node_modules/kdbush": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+			"license": "ISC"
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -2278,6 +2421,57 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/mapbox-gl": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.18.0.tgz",
+			"integrity": "sha512-xMr9HUoof0qPqWrVNK+kLiPtU1ogyfR6cihGSTB4eQAzdfFuMTC7CPrbpbZK0oUKQxXI/1qvB35FXZIK7kfR9w==",
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"workspaces": [
+				"src/style-spec",
+				"test/build/vite",
+				"test/build/webpack",
+				"test/build/typings"
+			],
+			"dependencies": {
+				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
+				"@mapbox/mapbox-gl-supported": "^3.0.0",
+				"@mapbox/point-geometry": "^1.1.0",
+				"@mapbox/tiny-sdf": "^2.0.6",
+				"@mapbox/unitbezier": "^0.0.1",
+				"@mapbox/vector-tile": "^2.0.4",
+				"@mapbox/whoots-js": "^3.1.0",
+				"@types/geojson": "^7946.0.16",
+				"@types/geojson-vt": "^3.2.5",
+				"@types/mapbox__point-geometry": "^0.1.4",
+				"@types/pbf": "^3.0.5",
+				"@types/supercluster": "^7.1.3",
+				"cheap-ruler": "^4.0.0",
+				"csscolorparser": "~1.0.3",
+				"earcut": "^3.0.1",
+				"geojson-vt": "^4.0.2",
+				"gl-matrix": "^3.4.4",
+				"grid-index": "^1.1.0",
+				"kdbush": "^4.0.2",
+				"martinez-polygon-clipping": "^0.8.1",
+				"murmurhash-js": "^1.0.0",
+				"pbf": "^4.0.1",
+				"potpack": "^2.0.0",
+				"quickselect": "^3.0.0",
+				"supercluster": "^8.0.1",
+				"tinyqueue": "^3.0.0"
+			}
+		},
+		"node_modules/martinez-polygon-clipping": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
+			"integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"robust-predicates": "^2.0.4",
+				"splaytree": "^0.1.4",
+				"tinyqueue": "3.0.0"
+			}
+		},
 		"node_modules/mdast-util-to-hast": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
@@ -2488,6 +2682,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/murmurhash-js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+			"license": "MIT"
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2533,6 +2733,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pbf": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"resolve-protobuf-schema": "^2.1.0"
+			},
+			"bin": {
+				"pbf": "bin/pbf"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2546,6 +2758,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2600,12 +2813,19 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/potpack": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+			"integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+			"license": "ISC"
+		},
 		"node_modules/prettier": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -2638,11 +2858,23 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/protocol-buffers-schema": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+			"license": "MIT"
+		},
 		"node_modules/qrcode-generator": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
 			"integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
 			"license": "MIT"
+		},
+		"node_modules/quickselect": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+			"integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+			"license": "ISC"
 		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
@@ -2684,6 +2916,21 @@
 			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/resolve-protobuf-schema": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+			"integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"protocol-buffers-schema": "^3.3.1"
+			}
+		},
+		"node_modules/robust-predicates": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+			"integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+			"license": "Unlicense"
 		},
 		"node_modules/rollup": {
 			"version": "4.53.3",
@@ -2817,6 +3064,12 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/splaytree": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+			"integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+			"license": "MIT"
+		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -2858,11 +3111,21 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"license": "0BSD"
 		},
+		"node_modules/supercluster": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+			"integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+			"license": "ISC",
+			"dependencies": {
+				"kdbush": "^4.0.2"
+			}
+		},
 		"node_modules/svelte": {
 			"version": "5.43.14",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.43.14.tgz",
 			"integrity": "sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2983,6 +3246,7 @@
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -3013,7 +3277,8 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
 			"integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -3045,6 +3310,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
+		},
+		"node_modules/tinyqueue": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+			"integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+			"license": "ISC"
 		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
@@ -3089,6 +3360,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3206,6 +3478,7 @@
 			"integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@sveltejs/kit": "^2.48.5",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.17",
+		"@types/google.maps": "^3.58.1",
 		"@types/qrcode-generator": "^0.0.16",
 		"bits-ui": "^2.14.4",
 		"clsx": "^2.1.1",
@@ -48,6 +49,7 @@
 		"class-variance-authority": "^0.7.1",
 		"libphonenumber-js": "^1.12.29",
 		"lucide-svelte": "^0.554.0",
+		"mapbox-gl": "^3.18.0",
 		"qrcode-generator": "^2.0.4",
 		"svelte-floating-ui": "^1.6.2",
 		"svelte-motion": "^0.12.2"

--- a/src/lib/components/ui/map/index.ts
+++ b/src/lib/components/ui/map/index.ts
@@ -1,0 +1,18 @@
+import Map from "./map.svelte";
+import Marker from "./marker.svelte";
+
+export {
+    Map as Root,
+    Marker
+};
+
+export type LatLng = {
+    lat: number;
+    lng: number;
+};
+
+export type MapProviderName = 'google' | 'mapbox';
+
+export interface MapProviderConfig {
+    apiKey: string;
+}

--- a/src/lib/components/ui/map/map.svelte
+++ b/src/lib/components/ui/map/map.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+	import type { MapInstance } from './mapInstance';
+
+	let {
+		map,
+		options = {},
+		class: className,
+		children,
+		...restProps
+	}: {
+		map: MapInstance;
+		options?: Record<string, any>;
+		class?: string;
+		children?: Snippet;
+	} = $props();
+
+	let container: HTMLDivElement | null = $state(null);
+	let mounted = $state(false);
+
+	$effect(() => {
+		if (container) {
+			map.mount(container).then(() => {
+				console.log('Map mounted successfully');
+				mounted = true;
+				map.setCenter(options.center);
+			});
+		}
+
+		return () => map.destroy();
+	});
+</script>
+
+<div
+	bind:this={container}
+	id="map"
+	class={cn('flex flex-col gap-4 w-full h-full relative', className)}
+	{...restProps}
+>
+	{#if mounted}
+		{@render children?.()}
+	{:else}
+		<div class="absolute inset-0 flex items-center justify-center">
+			<span class="text-muted-foreground">Loading map...</span>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/ui/map/mapInstance.ts
+++ b/src/lib/components/ui/map/mapInstance.ts
@@ -1,0 +1,56 @@
+import type { LatLng, MapProviderName } from './index';
+import type { MapProvider } from './provider';
+
+type MapInstanceOptions = {
+    provider: MapProviderName;
+    apiKey: string;
+};
+
+export class MapInstance {
+    private provider!: MapProvider;
+    private ready!: boolean;
+
+    constructor(private options: MapInstanceOptions) { }
+
+    async mount(container: HTMLElement) {
+        if (!this.provider) {
+            this.provider = await this.loadProvider();
+            this.ready = await this.provider.mount(container);
+        }
+
+        return this.ready;
+    }
+
+    private async loadProvider(): Promise<MapProvider> {
+        switch (this.options.provider) {
+            case 'google': {
+                const mod = await import('./providers/google.ts');
+                return new mod.default(this.options.apiKey);
+            }
+
+            case 'mapbox': {
+                const mod = await import('./providers/mapbox.ts');
+                return new mod.default(this.options.apiKey);
+            }
+
+            default:
+                throw new Error('Unknown map provider');
+        }
+    }
+
+    async addMarker(position: LatLng) {
+        if (this.ready) {
+            this.provider.addMarker(position);
+        }
+    }
+
+    async setCenter(position: LatLng) {
+        if (this.ready) {
+            this.provider.setCenter(position);
+        }
+    }
+
+    destroy() {
+        this.provider?.destroy();
+    }
+}

--- a/src/lib/components/ui/map/marker.svelte
+++ b/src/lib/components/ui/map/marker.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { LatLng } from '.';
+	import type { MapInstance } from './mapInstance';
+
+	let {
+		map,
+		position = { lat: 0, lng: 0 },
+		...restProps
+	}: {
+		map: MapInstance;
+		position?: LatLng;
+	} = $props();
+
+	$effect(() => {
+		map.addMarker(position);
+	});
+</script>

--- a/src/lib/components/ui/map/provider.ts
+++ b/src/lib/components/ui/map/provider.ts
@@ -1,0 +1,8 @@
+import type { LatLng } from ".";
+
+export interface MapProvider {
+    mount(container: HTMLElement): Promise<boolean>;
+    setCenter(position: LatLng): void;
+    addMarker(position: LatLng): void;
+    destroy(): void;
+}

--- a/src/lib/components/ui/map/providers/google.ts
+++ b/src/lib/components/ui/map/providers/google.ts
@@ -1,0 +1,61 @@
+import type { MapProvider } from '../provider';
+import type { LatLng } from '../index';
+
+export default class GoogleProvider implements MapProvider {
+    private map!: google.maps.Map;
+    private markers: google.maps.marker.AdvancedMarkerElement[] = [];
+    private apiKey: string;
+
+    constructor(apiKey: string) {
+        this.apiKey = apiKey;
+    }
+
+    async mount(container: HTMLElement) {
+        return new Promise<boolean>(async (resolve, reject) => {
+            try {
+                if (!(window as any).google?.maps) {
+                    await this.loadScript();
+                }
+
+                this.map = new google.maps.Map(container, {
+                    center: { lat: 0, lng: 0 },
+                    zoom: 8,
+                    mapId: container.id || "map"
+                });
+                resolve(true);
+            } catch (error) {
+                console.error('Error mounting Google Map:', error);
+                reject(false);
+            }
+        })
+    }
+
+    setCenter(position: LatLng) {
+        this.map.setCenter(position);
+    }
+
+    addMarker(position: LatLng) {
+        const marker = new google.maps.marker.AdvancedMarkerElement({
+            position,
+            map: this.map
+        });
+
+        this.markers.push(marker);
+    }
+
+    destroy() {
+        this.markers.forEach(m => m.map = null);
+        this.markers = [];
+    }
+
+    private loadScript() {
+        return new Promise<void>((resolve) => {
+            const script = document.createElement('script');
+            script.src =
+                `https://maps.googleapis.com/maps/api/js?key=${this.apiKey}&libraries=maps,marker`;
+            script.async = true;
+            script.onload = () => resolve();
+            document.head.appendChild(script);
+        });
+    }
+}

--- a/src/lib/components/ui/map/providers/mapbox.ts
+++ b/src/lib/components/ui/map/providers/mapbox.ts
@@ -1,0 +1,44 @@
+import type { MapProvider } from '../provider';
+import type { LatLng } from '../index';
+
+export default class MapboxProvider implements MapProvider {
+    private map!: any;
+    private mapbox!: any;
+
+    constructor(private apiKey: string) { }
+
+    async mount(container: HTMLElement) {
+        return new Promise<boolean>(async (resolve, reject) => {
+            try {
+                const mapboxgl = await import('mapbox-gl');
+
+                mapboxgl.default.accessToken = this.apiKey;
+                this.mapbox = mapboxgl.default;
+
+                this.map = new mapboxgl.default.Map({
+                    container,
+                    style: 'mapbox://styles/mapbox/streets-v11',
+                    center: [0, 0],
+                    zoom: 8
+                });
+                this.map.on('load', () => resolve(true));
+            } catch (error) {
+                return reject(false);
+            }
+        });
+    }
+
+    setCenter({ lat, lng }: LatLng) {
+        this.map.setCenter([lng, lat]);
+    }
+
+    addMarker({ lat, lng }: LatLng) {
+        new this.mapbox.Marker()
+            .setLngLat([lng, lat])
+            .addTo(this.map);
+    }
+
+    destroy() {
+        this.map.remove();
+    }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,6 +45,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
+	import { Map } from '@lucide/svelte';
 
 	let { children } = $props();
 
@@ -99,6 +100,7 @@
 				},
 				{ href: '/components/cursor', label: 'Cursor', icon: MousePointer2, new: false },
 				{ href: '/components/image-zoom', label: 'Image Zoom', icon: ImagePlus, new: false },
+				{ href: '/components/map', label: 'Map', icon: Map, new: true },
 				{ href: '/components/shiny-button', label: 'Shiny Button', icon: Sparkle, new: false },
 				{ href: '/components/spotlight-card', label: 'Spotlight Card', icon: Square, new: false },
 				{ href: '/components/video', label: 'Video', icon: SquarePlay, new: false }

--- a/src/routes/components/map/+page.svelte
+++ b/src/routes/components/map/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import * as Map from '$lib/components/ui/map';
+	import * as DocPage from '$lib/components/feature/doc-page';
+	import { MapInstance } from '$lib/components/ui/map/mapInstance';
+	import { PUBLIC_GOOGLE_MAPS_API_KEY } from '$env/static/public';
+
+	const mapOptions = {
+		center: { lat: 40.7128, lng: -74.006 },
+		zoom: 2
+	};
+
+	const map = new MapInstance({
+		provider: 'google',
+		apiKey: PUBLIC_GOOGLE_MAPS_API_KEY
+	});
+</script>
+
+<DocPage.Root>
+	<DocPage.Header>
+		<DocPage.Title>Map</DocPage.Title>
+		<DocPage.Description
+			>A multi-target Map rendering component. Currently supports Google Maps and Mapbox.</DocPage.Description
+		>
+	</DocPage.Header>
+
+	<DocPage.Content>
+		<DocPage.Example>
+			<DocPage.Preview class="flex flex-col gap-4 min-h-[300px] items-center overflow-hidden">
+				<div class="w-full h-full">
+					<Map.Root {map} options={mapOptions}>
+						<Map.Marker {map} position={{ lat: 40.7128, lng: -74.006 }} />
+					</Map.Root>
+				</div>
+			</DocPage.Preview>
+
+			<DocPage.Code
+				code={`<script lang="ts">
+  import * as Map from '$lib/components/ui/map';
+  import { MapInstance } from '$lib/components/ui/map/mapInstance';
+
+  const map = new MapInstance({
+    provider: 'google',
+    apiKey: 'YOUR_GOOGLE_MAPS_API_KEY'
+  });
+<\/script>
+
+<Map.Root
+  id="map"
+  options={{
+    center: { lat: 40.7128, lng: -74.006 },
+    zoom: 2
+  }}
+>
+  <Map.Marker position={{ lat: 40.7128, lng: -74.006 }} />
+</Map.Root>`}
+			/>
+		</DocPage.Example>
+
+		<DocPage.Heading>Installation</DocPage.Heading>
+		{@const componentName = 'map'}
+		<DocPage.Text
+			>Run the following command to install the `{componentName}` components:</DocPage.Text
+		>
+		<DocPage.PM
+			command="execute"
+			args={[
+				'shadcn-svelte@latest',
+				'add',
+				'https://more-shadcn.noair.fun/r/' + componentName + '.json'
+			]}
+		/>
+	</DocPage.Content>
+</DocPage.Root>


### PR DESCRIPTION
As discussed in DMs, here the first (_very much unfinished_) draft of a multi-target Map component.

The Mapbox side is untested, but according to the docs, it should work. I'll look into this soon.
The Google Maps side works and markers behave as expected.

Markers are still very basic and currently only support the `position` property, but if the APIs permit, I'll try to add colors, inner HTML, and all the other fancy jazz. The good thing is that multiple markers can easily be added via the `Map.Marker` component.

Typings aren't perfect yet. I'm considering making a union type for each provider so that they can have provider-specific props as to not limit the user. This will, however, break provider parity but that can be annotated.

Additionally, the necessary provider library is loaded dynamically. Whether this is a good thing or not is yet to be determined, but I hope this'll create less bloat for the end-user.

<br>

<img width="2550" height="1269" alt="image" src="https://github.com/user-attachments/assets/e10b11c4-f770-48f5-9b1d-952929002d1b" />

<br>
<br>

TODO:
- [ ] Add "isAllowed" prop for users to link to their privacy popups
- [ ] Validate Mapbox
- [ ] Add Marker styling
- [ ] Extend Map config options (limit view, disable zoom, etc.)
- [ ] Add Marker events (click, body, etc.)
- [ ] Add Areas/Zones
- [ ] More TBD...
