### PR TITLE
fix: broken component link in docs

### DIFF
--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -34,7 +34,7 @@
 				for even more components!
 			</p>
 			<div class="flex items-center gap-4 pt-2">
-				<ShinyButton href="/components/autocomplete">
+				<ShinyButton href="/docs/components/autocomplete">
 					Browse Components
 					<ArrowRight class="ml-2 h-4 w-4" />
 				</ShinyButton>


### PR DESCRIPTION
noticed this and it annoyed me so i fixed it

<img width="497" height="381" alt="image" src="https://github.com/user-attachments/assets/87998de8-0ef4-470a-a2c8-a3b538cecfc2" />
<img width="652" height="227" alt="image" src="https://github.com/user-attachments/assets/75b30363-e1ec-4ac5-90b9-d75b9bf78119" />
