### PR TITLE
Fix background style syntax in color picker

### DIFF
--- a/src/lib/components/ui/color-picker/color-picker.svelte
+++ b/src/lib/components/ui/color-picker/color-picker.svelte
@@ -382,8 +382,7 @@
 			<div
 				bind:this={hueRef}
 				class="relative h-3 w-full cursor-pointer rounded-full shadow-sm ring-1 ring-black/5 touch-none"
-				style:background="linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%,
-				#f0f 83%, #f00 100%)"
+				style:background={"linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)"}
 				role="slider"
 				aria-valuenow={h}
 				tabindex="0"


### PR DESCRIPTION
Because of prettier and formatting we have a broken style syntax. This places it inline and is compatible with prettier.