### PR TITLE
@feat/api

### DIFF
--- a/src/lib/components/feature/doc-page/doc-page-code.svelte
+++ b/src/lib/components/feature/doc-page/doc-page-code.svelte
@@ -1,21 +1,25 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
-	import type { Snippet } from 'svelte';
 	import * as Code from '$lib/components/ui/code';
+	import { cn } from '$lib/utils';
 
 	let {
 		class: className,
-		code
+		code,
+		lang = 'svelte'
 	}: {
 		class?: string;
 		code: string;
+		lang?: 'svelte' | 'bash' | 'diff' | 'javascript' | 'json' | 'typescript' | undefined;
 	} = $props();
 </script>
 
 <Code.Root
-	lang="svelte"
+	{lang}
 	{code}
-	class="rounded-t-none rounded-b-md border-t-0 w-full max-h-[350px] overflow-scroll bg-muted"
+	class={cn(
+		'rounded-t-none rounded-b-md border-t-0 w-full max-h-[350px] overflow-scroll bg-muted',
+		className
+	)}
 >
 	<Code.CopyButton />
 </Code.Root>

--- a/src/lib/components/ui/api-documentation/api-documentation.svelte
+++ b/src/lib/components/ui/api-documentation/api-documentation.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+	import type { APIRegistry } from '.';
+
+	let { api }: { api: APIRegistry } = $props();
+
+	function formatValue(value: unknown): string {
+		if (value === undefined) return '—';
+		if (value === null) return 'null';
+		if (typeof value === 'string') return value;
+		if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
+	}
+
+	function yesNo(value: boolean | undefined): string {
+		return value ? 'Yes' : '—';
+	}
+
+	function kindBadgeClasses(kind: string): string {
+		switch (kind) {
+			case 'prop':
+				return 'bg-blue-50 text-blue-700 ring-blue-200';
+			case 'param':
+				return 'bg-violet-50 text-violet-700 ring-violet-200';
+			case 'field':
+				return 'bg-emerald-50 text-emerald-700 ring-emerald-200';
+			case 'method':
+				return 'bg-amber-50 text-amber-700 ring-amber-200';
+			default:
+				return 'bg-zinc-50 text-zinc-700 ring-zinc-200';
+		}
+	}
+
+	function typeBadgeClasses(type: string): string {
+		switch (type) {
+			case 'component':
+				return 'bg-sky-50 text-sky-700 ring-sky-200';
+			case 'snippet':
+				return 'bg-fuchsia-50 text-fuchsia-700 ring-fuchsia-200';
+			case 'function':
+				return 'bg-green-50 text-green-700 ring-green-200';
+			case 'class':
+				return 'bg-orange-50 text-orange-700 ring-orange-200';
+			default:
+				return 'bg-zinc-50 text-zinc-700 ring-zinc-200';
+		}
+	}
+</script>
+
+<div class="flex flex-col gap-4 w-full">
+	<div class="p-4">
+		<h1 class="text-3xl font-semibold tracking-tight text-foreground">
+			{api.name}
+		</h1>
+
+		{#if api.description}
+			<p class="max-w-3xl text-sm leading-6 text-muted-foreground">
+				{api.description}
+			</p>
+		{/if}
+	</div>
+
+	<div class="space-y-6">
+		{#each api.items as item}
+			<section class="overflow-hidden rounded-2xl border border-border bg-background shadow-sm">
+				<div class="border-b border-border bg-background/70 px-6 py-5">
+					<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+						<div class="min-w-0 space-y-1">
+							<div class="flex items-center gap-3">
+								<h2 class="text-xl font-semibold tracking-tight text-foreground">
+									{item.name}
+								</h2>
+
+								<span
+									class={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${typeBadgeClasses(item.type)}`}
+								>
+									{item.type}
+								</span>
+							</div>
+
+							{#if item.description}
+								<p class="text-sm leading-6">
+									{item.description}
+								</p>
+							{/if}
+						</div>
+
+						<div class="shrink-0 text-sm">
+							{item.members.length}
+							{item.members.length === 1 ? 'member' : 'members'}
+						</div>
+					</div>
+				</div>
+
+				{#if item.members.length > 0}
+					<div class="overflow-x-auto">
+						<table class="min-w-full divide-y divide-border">
+							<thead class="bg-background">
+								<tr class="text-left">
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Kind
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Name
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Type
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Default
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Optional
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Bindable
+									</th>
+									<th scope="col" class="px-6 py-3 text-xs font-semibold uppercase tracking-wide">
+										Description
+									</th>
+								</tr>
+							</thead>
+
+							<tbody class="divide-y divide-border bg-background">
+								{#each item.members as member}
+									<tr class="align-top hover:bg-zinc-50/60">
+										<td class="whitespace-nowrap px-6 py-4">
+											<span
+												class={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${kindBadgeClasses(member.kind)}`}
+											>
+												{member.kind}
+											</span>
+										</td>
+
+										<td class="px-6 py-4">
+											<code
+												class="rounded-md bg-card-foreground px-2 py-1 text-xs font-medium text-card"
+											>
+												{member.key}
+											</code>
+										</td>
+
+										<td class="px-6 py-4">
+											<code
+												class="whitespace-pre-wrap wrap-break-word rounded-md bg-card-foreground px-2 py-1 text-xs text-card"
+											>
+												{member.valueType}
+											</code>
+										</td>
+
+										<td class="px-6 py-4 text-sm text-muted">
+											{formatValue(member.defaultValue)}
+										</td>
+
+										<td class="px-6 py-4 text-sm text-muted">
+											{yesNo(member.optional)}
+										</td>
+
+										<td class="px-6 py-4 text-sm text-muted">
+											{yesNo(member.bindable)}
+										</td>
+
+										<td class="px-6 py-4 text-sm leading-6 text-zinc-600">
+											{member.description ?? '—'}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{:else}
+					<div class="px-6 py-8 text-sm text-muted">No members defined.</div>
+				{/if}
+
+				{#if item.returns}
+					<div class="border-t border-border bg-background px-6 py-4">
+						<div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+							<span class="text-sm font-medium text-foreground">Returns</span>
+							<code class="w-fit rounded-md bg-card-foreground px-2 py-1 text-xs text-card">
+								{item.returns.valueType}
+							</code>
+
+							{#if item.returns.description}
+								<span class="text-sm text-muted">
+									{item.returns.description}
+								</span>
+							{/if}
+						</div>
+					</div>
+				{/if}
+			</section>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/ui/api-documentation/index.ts
+++ b/src/lib/components/ui/api-documentation/index.ts
@@ -1,0 +1,196 @@
+export type APIEntityType = 'component' | 'snippet' | 'function' | 'class';
+export type APIMemberKind = 'prop' | 'param' | 'field' | 'method';
+
+export type APIValue = string | number | boolean | null | APIValue[] | { [key: string]: APIValue };
+
+export interface APIMember {
+	kind: APIMemberKind;
+	key: string;
+	valueType: string;
+	description?: string;
+	bindable?: boolean;
+	defaultValue?: APIValue;
+	optional?: boolean;
+}
+
+export interface APIReturn {
+	valueType: string;
+	description?: string;
+}
+
+export interface APIEntity {
+	type: APIEntityType;
+	name: string;
+	description?: string;
+	members: APIMember[];
+	returns?: APIReturn;
+}
+
+export interface APIRegistry {
+	name: string;
+	description?: string;
+	items: APIEntity[];
+}
+
+export interface APIMemberOptions {
+	description?: string;
+	bindable?: boolean;
+	defaultValue?: APIValue;
+	optional?: boolean;
+}
+
+export interface APIReturnOptions {
+	description?: string;
+}
+
+function deepClone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+abstract class BaseEntityBuilder<TBuilder> {
+	protected readonly entity: APIEntity;
+
+	protected constructor(type: APIEntityType, name: string, description?: string) {
+		this.entity = {
+			type,
+			name,
+			description,
+			members: []
+		};
+	}
+
+	protected self(): TBuilder {
+		return this as unknown as TBuilder;
+	}
+
+	protected addMember(
+		kind: APIMemberKind,
+		key: string,
+		valueType: string,
+		options: APIMemberOptions = {}
+	): TBuilder {
+		this.entity.members.push({
+			kind,
+			key,
+			valueType,
+			description: options.description,
+			bindable: options.bindable,
+			defaultValue: options.defaultValue,
+			optional: options.optional
+		});
+
+		return this.self();
+	}
+
+	description(description: string): TBuilder {
+		this.entity.description = description;
+		return this.self();
+	}
+
+	prop(key: string, valueType: string, options: APIMemberOptions = {}): TBuilder {
+		return this.addMember('prop', key, valueType, options);
+	}
+
+	param(key: string, valueType: string, options: APIMemberOptions = {}): TBuilder {
+		return this.addMember('param', key, valueType, options);
+	}
+
+	field(key: string, valueType: string, options: APIMemberOptions = {}): TBuilder {
+		return this.addMember('field', key, valueType, options);
+	}
+
+	method(key: string, valueType: string, options: APIMemberOptions = {}): TBuilder {
+		return this.addMember('method', key, valueType, options);
+	}
+
+	returns(valueType: string, options: APIReturnOptions = {}): TBuilder {
+		this.entity.returns = {
+			valueType,
+			description: options.description
+		};
+
+		return this.self();
+	}
+
+	build(): APIEntity {
+		return deepClone(this.entity);
+	}
+}
+
+export class ComponentBuilder extends BaseEntityBuilder<ComponentBuilder> {
+	constructor(name: string, description?: string) {
+		super('component', name, description);
+	}
+}
+
+export class SnippetBuilder extends BaseEntityBuilder<SnippetBuilder> {
+	constructor(name: string, description?: string) {
+		super('snippet', name, description);
+	}
+}
+
+export class FunctionBuilder extends BaseEntityBuilder<FunctionBuilder> {
+	constructor(name: string, description?: string) {
+		super('function', name, description);
+	}
+}
+
+export class ClassBuilder extends BaseEntityBuilder<ClassBuilder> {
+	constructor(name: string, description?: string) {
+		super('class', name, description);
+	}
+}
+
+type EntityBuilder = ComponentBuilder | SnippetBuilder | FunctionBuilder | ClassBuilder;
+type Configure<T extends EntityBuilder> = (builder: T) => T | void;
+
+export class APIBuilder {
+	private readonly registry: APIRegistry;
+
+	constructor(name: string, description?: string) {
+		this.registry = {
+			name,
+			description,
+			items: []
+		};
+	}
+
+	setDescription(description: string): this {
+		this.registry.description = description;
+		return this;
+	}
+
+	private addEntity<T extends EntityBuilder>(builder: T, configure?: Configure<T>): this {
+		const configured = configure?.(builder) ?? builder;
+		this.registry.items.push(configured.build());
+		return this;
+	}
+
+	component(name: string, description?: string, configure?: Configure<ComponentBuilder>): this {
+		return this.addEntity(new ComponentBuilder(name, description), configure);
+	}
+
+	snippet(name: string, description?: string, configure?: Configure<SnippetBuilder>): this {
+		return this.addEntity(new SnippetBuilder(name, description), configure);
+	}
+
+	function(name: string, description?: string, configure?: Configure<FunctionBuilder>): this {
+		return this.addEntity(new FunctionBuilder(name, description), configure);
+	}
+
+	class(name: string, description?: string, configure?: Configure<ClassBuilder>): this {
+		return this.addEntity(new ClassBuilder(name, description), configure);
+	}
+
+	build(): APIRegistry {
+		return deepClone(this.registry);
+	}
+
+	toJSON(): APIRegistry {
+		return this.build();
+	}
+}
+
+export function defineAPI(name: string, description?: string): APIBuilder {
+	return new APIBuilder(name, description);
+}

--- a/src/lib/config/docs.ts
+++ b/src/lib/config/docs.ts
@@ -35,7 +35,8 @@ import {
 	Package,
 	Import,
 	ClockFading,
-	Tickets
+	Tickets,
+	BookOpen
 } from '@lucide/svelte';
 
 export const COMPONENT_URL = '/docs/components';
@@ -192,6 +193,12 @@ export const docsConfig = [
 	{
 		title: 'Data Display',
 		links: [
+			{
+				href: `${COMPONENT_URL}/api-documentation`,
+				label: 'API Documentation',
+				icon: BookOpen,
+				new: true
+			},
 			{
 				href: `${COMPONENT_URL}/big-calendar`,
 				label: 'Big Calendar',

--- a/src/routes/docs/components/api-documentation/+page.svelte
+++ b/src/routes/docs/components/api-documentation/+page.svelte
@@ -65,9 +65,9 @@
 				<ApiDocumentation api={buttonAPI} />
 			</DocPage.Preview>
 		</DocPage.Example>
-		<!-- <Separator class="my-6" /> -->
+		<DocPage.Heading>Usage</DocPage.Heading>
 		<DocPage.Code
-			class="rounded"
+			class="rounded-t overflow-auto rounded-b-none"
 			lang="typescript"
 			code={`import { defineAPI } from '$lib/components/ui/api-documentation';
 const buttonAPI = defineAPI('Button', 'Button API')
@@ -115,6 +115,8 @@ const buttonAPI = defineAPI('Button', 'Button API')
     )
     .build();`}
 		/>
+		<Separator class="border-b border-background" />
+		<DocPage.Code lang="svelte" code={`<ApiDocumentation api={buttonAPI} />`} />
 
 		<DocPage.Heading>Installation</DocPage.Heading>
 		{@const componentName = 'api-documentation'}

--- a/src/routes/docs/components/api-documentation/+page.svelte
+++ b/src/routes/docs/components/api-documentation/+page.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	import * as DocPage from '$lib/components/feature/doc-page';
+	import ApiDocumentation from '$lib/components/ui/api-documentation/api-documentation.svelte';
+	import { defineAPI } from '$lib/components/ui/api-documentation';
+	import Separator from '$lib/components/ui/separator/separator.svelte';
+
+	const buttonAPI = defineAPI('Button', 'Button API')
+		.component('Button', 'Main button component', (component) =>
+			component
+				.prop('variant', '"primary" | "secondary"', {
+					description: 'Visual style of the button',
+					defaultValue: 'primary',
+					optional: true
+				})
+				.prop('disabled', 'boolean', {
+					description: 'Disables user interaction',
+					defaultValue: false,
+					optional: true,
+					bindable: true
+				})
+				.prop('children', 'Snippet', {
+					description: 'Rendered inner content',
+					optional: true
+				})
+		)
+		.snippet('icon', 'Optional icon renderer', (snippet) =>
+			snippet.param('size', 'number', {
+				description: 'Requested icon size',
+				defaultValue: 16,
+				optional: true
+			})
+		)
+		.function('focusButton', 'Focuses a button element', (fn) =>
+			fn
+				.param('el', 'HTMLButtonElement', {
+					description: 'Button element to focus'
+				})
+				.returns('void')
+		)
+		.class('ButtonController', 'Imperative controller API', (cls) =>
+			cls
+				.field('active', 'boolean', {
+					description: 'Current active state',
+					defaultValue: false
+				})
+				.method('toggle', '() => void', {
+					description: 'Toggles the active state'
+				})
+		)
+		.build();
+</script>
+
+<DocPage.Root>
+	<DocPage.Header>
+		<DocPage.Title>API Documentation</DocPage.Title>
+		<DocPage.Description>
+			An auto-generated API reference table for all components, snippets and utilities.
+		</DocPage.Description>
+	</DocPage.Header>
+
+	<DocPage.Content>
+		<DocPage.Example>
+			<Separator class="my-6" />
+			<DocPage.Preview class="relative h-full w-full overflow-x-scroll bg-muted/30">
+				<ApiDocumentation api={buttonAPI} />
+			</DocPage.Preview>
+		</DocPage.Example>
+		<!-- <Separator class="my-6" /> -->
+		<DocPage.Code
+			class="rounded"
+			lang="typescript"
+			code={`import { defineAPI } from '$lib/components/ui/api-documentation';
+const buttonAPI = defineAPI('Button', 'Button API')
+    .component('Button', 'Main button component', (component) =>
+        component
+            .prop('variant', '"primary" | "secondary"', {
+                description: 'Visual style of the button',
+                defaultValue: 'primary',
+                optional: true
+            })
+            .prop('disabled', 'boolean', {
+                description: 'Disables user interaction',
+                defaultValue: false,
+                optional: true,
+                bindable: true
+            })
+            .prop('children', 'Snippet', {
+                description: 'Rendered inner content',
+                optional: true
+            })
+    )
+    .snippet('icon', 'Optional icon renderer', (snippet) =>
+        snippet.param('size', 'number', {
+            description: 'Requested icon size',
+            defaultValue: 16,
+            optional: true
+        })
+    )
+    .function('focusButton', 'Focuses a button element', (fn) =>
+        fn
+            .param('el', 'HTMLButtonElement', {
+                description: 'Button element to focus'
+            })
+            .returns('void')
+    )
+    .class('ButtonController', 'Imperative controller API', (cls) =>
+        cls
+            .field('active', 'boolean', {
+                description: 'Current active state',
+                defaultValue: false
+            })
+            .method('toggle', '() => void', {
+                description: 'Toggles the active state'
+            })
+    )
+    .build();`}
+		/>
+
+		<DocPage.Heading>Installation</DocPage.Heading>
+		{@const componentName = 'api-documentation'}
+		<DocPage.Text
+			>Run the following command to install the `{componentName}` components:</DocPage.Text
+		>
+		<DocPage.PM
+			command="execute"
+			args={[
+				'shadcn-svelte@latest',
+				'add',
+				'https://more-shadcn.noair.fun/r/' + componentName + '.json'
+			]}
+		/>
+	</DocPage.Content>
+</DocPage.Root>


### PR DESCRIPTION
This PR adds a small, flexible system to define and render component APIs, which has been a long requested feature.
As discussed in DMs, this mostly focuses on the logic side of things, although I took the liberty of making a crude front-end for it already.

Notable points:
The entire builder can be used through a single method, and by passing it props, iot generate the necessary JSON, which can get parsed by the `api-documentation` component.

Examples are provided in the usual way. Additionally I modified the `doc-page-code.svelte` element to allow for language specifications, since this component mostly requires typescript and not svelte. 

Feel free to modify the renderer component. It's not terrible as-is, but could definitely be better. Splitting it into snipped might be smart here too.

<img width="830" height="1240" alt="image" src="https://github.com/user-attachments/assets/cfb789cd-0ea8-4780-a327-758dfe73033d" />
